### PR TITLE
Fix type hinting for 3.8

### DIFF
--- a/src/solaxx3/solaxx3.py
+++ b/src/solaxx3/solaxx3.py
@@ -28,7 +28,7 @@ class SolaxX3:
         method: str = "rtu",
         port: str = "/dev/ttyUSB0",
         baudrate: int = 115200,
-        timeout: int | float = 3,
+        timeout: int = 3,
         parity: Literal["E", "O", "N"] = "N",
         stopbits: Literal[0, 1, 2] = 1,
         bytesize: Literal[7, 8] = 8,


### PR DESCRIPTION
Fix type hinting to be compatible with Python 3.8