### PR TITLE
Type hinting for Python 3.8+

### DIFF
--- a/database/collect_stats.py
+++ b/database/collect_stats.py
@@ -51,7 +51,7 @@ if s.connect():
 
     try:
         # create the sql statement
-        QUERY = """REPLACE INTO solax_local (
+        SQL_QUERY = """REPLACE INTO solax_local (
                                       uploadTime,
                                       inverter_status,
                                       dc_solar_power,
@@ -88,18 +88,18 @@ if s.connect():
             power_dc2,
         )
 
-        mycursor.execute(QUERY, values)
+        mycursor.execute(SQL_QUERY, values)
         mydb.commit()
 
         # update daily values
-        QUERY = """REPLACE INTO solax_daily (
+        SQL_QUERY = """REPLACE INTO solax_daily (
                                         uploadDate,
                                         feed_in,
                                         total_yield
             ) VALUES (%s, %s, %s)
             """
         values = (uploadDate, feed_in_today, etoday_togrid)
-        mycursor.execute(QUERY, values)
+        mycursor.execute(SQL_QUERY, values)
         mydb.commit()
 
     except mysql.connector.Error as error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solaxx3"
-version = "1.0.1"
+version = "1.0.2"
 description = "Read Solax X3 inverter registers via modbus interface (RS-485)"
 readme = "README.md"
 authors = [{ name = "Flavius Moldovan", email = "mkfam@protonmail.com" }]

--- a/src/solaxx3/__init__.py
+++ b/src/solaxx3/__init__.py
@@ -1,3 +1,3 @@
 """Version of the Solax RTU package"""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/solaxx3/solax_registers_info.py
+++ b/src/solaxx3/solax_registers_info.py
@@ -1,10 +1,24 @@
 """Module holding information about inverter's registers."""
 
+from typing import Dict, Union, Literal
+
+FIELDS = Literal[
+    "address",
+    "register_type",
+    "data_format",
+    "si_adj",
+    "signed",
+    "data_unit",
+    "data_length",
+    "description",
+]
+FIELD_VALUES = Union[int, str]
+
 
 class SolaxRegistersInfo:
     """Class holding information about inverter's registers."""
 
-    _registers = {
+    _registers: Dict[str, Dict[FIELDS, FIELD_VALUES]] = {
         # input registers
         "grid_voltage": {
             "address": 0x0000,
@@ -3533,23 +3547,23 @@ class SolaxRegistersInfo:
         },
     }
 
-    def get_register_info(self, name: str):
+    def get_register_info(self, name: str) -> dict:
         """Get the information about a register."""
 
         return self._registers[name]
 
-    def list_register_names(self):
+    def list_register_names(self) -> list:
         """Return all registers defined in this class."""
 
         return list(self._registers.keys())
 
-    def list_holding_registers(self):
+    def list_holding_registers(self) -> list:
         """Return all holding registers defined in this class."""
 
         f = lambda register: self._registers[register]["register_type"] == "holding"
         return list(filter(f, self._registers))
 
-    def list_input_registers(self):
+    def list_input_registers(self) -> list:
         """Return all input registers defined in this class."""
 
         f = lambda register: self._registers[register]["register_type"] == "input"

--- a/src/solaxx3/solaxx3.py
+++ b/src/solaxx3/solaxx3.py
@@ -51,6 +51,7 @@ class SolaxX3:
 
     def connect(self) -> bool:
         """Connect to the inverter and return if it was successful."""
+
         self.connected: bool = self.client.connect()
         return self.connected
 

--- a/src/solaxx3/solaxx3.py
+++ b/src/solaxx3/solaxx3.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from struct import unpack
-from typing import Any, Dict, Iterable, List, Literal, Union
+from typing import Any, Dict, Iterable, List, Literal, Tuple, Union
 
 from pymodbus.client import ModbusSerialClient
 
@@ -150,7 +150,7 @@ class SolaxX3:
 
     def _read_register_value(
         self, register_info: Dict[FIELDS, FIELD_VALUES]
-    ) -> tuple[Union[float, str, datetime], str]:
+    ) -> Tuple[Union[float, str, datetime], str]:
         """Read the values from a register based on length and sign.
 
         Parameters:
@@ -161,7 +161,7 @@ class SolaxX3:
         val = self._read_format_register_value(register_info)
         return (val, register_info["data_unit"])
 
-    def read(self, name: str) -> tuple[Union[float, str, datetime], str]:
+    def read(self, name: str) -> Tuple[Union[float, str, datetime], str]:
         """Retrieve the value for the register with the provided name"""
 
         registers = SolaxRegistersInfo()


### PR DESCRIPTION
Used the typing module to make type hinting to work for Python 3.8 and upward.