### PR TITLE
Tests can be run with dependencies installed

### DIFF
--- a/database/mysql_data_source.py
+++ b/database/mysql_data_source.py
@@ -52,7 +52,11 @@ class MySQLDataSource(DataSourceDb):
         for index, unit in enumerate(export_data):
             database, table_name, data = unit.values()
 
-            if not hasattr(self, "db") or not hasattr(self, "cursor") or not self.db.is_connected():
+            if (
+                not hasattr(self, "db")
+                or not hasattr(self, "cursor")
+                or not self.db.is_connected()
+            ):
                 self.db = mysql.connector.connect(
                     user=self.user,
                     host=self.host,
@@ -65,13 +69,19 @@ class MySQLDataSource(DataSourceDb):
                     self.db.close()
                     raise
 
-            self.save_record(database, table_name, data, True, index + 1 == len(export_data))
+            self.save_record(
+                database, table_name, data, True, index + 1 == len(export_data)
+            )
 
     def create_query(self, table_name: str, data: dict) -> Tuple[str, list]:
         columns = list(data.keys())
         values = list(data.values())
 
         query = (
-            f"REPLACE INTO {table_name} (" + ", ".join(columns) + ") VALUES (" + ", ".join(["%s"] * len(columns)) + ")"
+            f"REPLACE INTO {table_name} ("
+            + ", ".join(columns)
+            + ") VALUES ("
+            + ", ".join(["%s"] * len(columns))
+            + ")"
         )
         return (query, values)

--- a/src/solaxx3/solaxx3.py
+++ b/src/solaxx3/solaxx3.py
@@ -17,7 +17,6 @@ class SolaxX3:
     """
     Class interacting with values from the inverter.
     Initialization parameters:
-        - method (default: rtu)
         - port (default: /dev/ttyUSB0 )
         - baudrate: Bits per second (default: 115,200 )
         - timeout: Timeout for a request, in seconds. (default: 3)
@@ -31,7 +30,6 @@ class SolaxX3:
 
     def __init__(
         self,
-        method: str = "rtu",
         port: str = "/dev/ttyUSB0",
         baudrate: int = 115200,
         timeout: int = 3,
@@ -43,7 +41,6 @@ class SolaxX3:
         self._holding_registers_values: List[int] = []
 
         self.client: ModbusSerialClient = ModbusSerialClient(
-            method=method,
             port=port,
             baudrate=baudrate,
             timeout=timeout,

--- a/tests/test_mysql_connector.py
+++ b/tests/test_mysql_connector.py
@@ -15,7 +15,7 @@ paths_to_extend = [current / "tests" / "mock_packages", current / "src"]
 for path in paths_to_extend:
     path_as_string = str(path)
     if path_as_string not in sys.path:
-        sys.path.append(path_as_string)
+        sys.path.insert(0, path_as_string)
 
 from database import read_and_save
 

--- a/tests/test_register_data.py
+++ b/tests/test_register_data.py
@@ -38,7 +38,7 @@ from src.solaxx3.solax_registers_info import SolaxRegistersInfo
 
 import_path = Path().resolve() / "tests" / "mock_packages"
 if str(import_path) not in sys.path:
-    sys.path.append(str(import_path))
+    sys.path.insert(0, str(import_path))
 
 REGISTER_FILE = "src/solaxx3/solax_registers_info.py"
 

--- a/tests/test_solaxx3.py
+++ b/tests/test_solaxx3.py
@@ -12,7 +12,7 @@ from tests.final_result import (
 
 import_path = Path().resolve() / "tests" / "mock_packages"
 if str(import_path) not in sys.path:
-    sys.path.append(str(import_path))
+    sys.path.insert(0, str(import_path))
 
 
 class Solaxx3Tests(unittest.TestCase):


### PR DESCRIPTION
Before, tests could not be run if the following packages were installed:
- solaxx3
- mysql-connector-python
- pymodbus.

Now, the tests can be run anyway in any environment.